### PR TITLE
fix onchange event not issued on select control

### DIFF
--- a/src/main/webapp/scripts/webapp.js
+++ b/src/main/webapp/scripts/webapp.js
@@ -130,4 +130,14 @@
             webAppController.showAllRadioBlocks(false);
         }
     });
+
+    Behaviour.specify("select.select", "azureAppService", 10000, function (e) {
+        var oldClick = e.onclick;
+        e.onclick = function () {
+            if (oldClick) {
+                oldClick();
+            }
+            fireEvent(e, "change");
+        };
+    });
 })()


### PR DESCRIPTION
according to Jenkins source code that: ` If there was no value pre-selected but after the call to updateListBox the first value is selected by default. This must not be considered a change`. That means the `onchange` event for every `select` element that was previously `""` and then the first option was selected. If there is only one option, the `onchange` event is never fired. I believe it's an issue for all `select`
 element.

I fix it by trigger `onchange` event when the option is clicked even if it's value not changed.