### PR TITLE
Set author/committer according to git config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.16.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Now we read author/committer from multiple git config files and if not found, will generate a default one instead of  throwing an error.