### PR TITLE
Support Java function

### DIFF
--- a/src/main/java/com/microsoft/jenkins/appservice/FunctionAppDeploymentCommandContext.java
+++ b/src/main/java/com/microsoft/jenkins/appservice/FunctionAppDeploymentCommandContext.java
@@ -5,10 +5,13 @@
  */
 package com.microsoft.jenkins.appservice;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PublishingProfile;
 import com.microsoft.jenkins.appservice.commands.AbstractCommandContext;
 import com.microsoft.jenkins.appservice.commands.DeploymentState;
+import com.microsoft.jenkins.appservice.commands.FTPDeployCommand;
 import com.microsoft.jenkins.appservice.commands.GitDeployCommand;
 import com.microsoft.jenkins.appservice.commands.IBaseCommandData;
 import com.microsoft.jenkins.appservice.commands.ICommand;
@@ -19,10 +22,12 @@ import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 
 public class FunctionAppDeploymentCommandContext extends AbstractCommandContext
-        implements GitDeployCommand.IGitDeployCommandData {
+        implements FTPDeployCommand.IFTPDeployCommandData, GitDeployCommand.IGitDeployCommandData {
 
     private final String filePath;
     private String sourceDirectory;
@@ -52,11 +57,60 @@ public class FunctionAppDeploymentCommandContext extends AbstractCommandContext
 
         HashMap<Class, TransitionInfo> commands = new HashMap<>();
 
-        Class startCommandClass = GitDeployCommand.class;
-        commands.put(GitDeployCommand.class, new TransitionInfo(new GitDeployCommand(), null, null));
+        Class startCommandClass;
+
+        boolean isJava = false;
+        try {
+            isJava = isJavaFunction(workspace, sourceDirectory, filePath);
+        } catch (IOException | InterruptedException e) {
+            throw new AzureCloudException(e);
+        }
+
+        if (isJava) {
+            // For Java function, use FTP-based deployment as it's the recommended way
+            startCommandClass = FTPDeployCommand.class;
+            commands.put(FTPDeployCommand.class, new TransitionInfo(
+                    new FTPDeployCommand(), null, null));
+        } else {
+            // For non-Java function, use Git-based deployment
+            startCommandClass = GitDeployCommand.class;
+            commands.put(GitDeployCommand.class, new TransitionInfo(
+                    new GitDeployCommand(), null, null));
+        }
 
         super.configure(run, workspace, listener, commands, startCommandClass);
         this.setDeploymentState(DeploymentState.Running);
+    }
+
+    static boolean isJavaFunction(final FilePath workspace, final String sourceDirectory, final String filePath)
+            throws IOException, InterruptedException {
+        FilePath sourceDir = workspace.child(Util.fixNull(sourceDirectory));
+        FilePath[] files = sourceDir.list(filePath);
+
+        for (final FilePath file : files) {
+            String fileName = file.getName();
+            if (fileName.equals("function.json")) {
+                String scriptPath = getScriptFileFromConfig(file);
+                if (scriptPath.toLowerCase().endsWith(".jar")) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static String getScriptFileFromConfig(final FilePath filePath) throws IOException, InterruptedException {
+        ObjectMapper mapper = new ObjectMapper();
+        try (InputStream stream = filePath.read()) {
+            JsonNode root = mapper.readTree(stream);
+            JsonNode scriptPathNode = root.get("scriptFile");
+            if (scriptPathNode == null) {
+                return "";
+            }
+
+            return scriptPathNode.asText("");
+        }
     }
 
     @Override

--- a/src/test/java/com/microsoft/jenkins/appservice/FunctionAppDeploymentCommandContextTest.java
+++ b/src/test/java/com/microsoft/jenkins/appservice/FunctionAppDeploymentCommandContextTest.java
@@ -7,18 +7,22 @@ package com.microsoft.jenkins.appservice;
 
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PublishingProfile;
-import com.microsoft.jenkins.appservice.FunctionAppDeploymentCommandContext;
 import com.microsoft.jenkins.appservice.commands.DeploymentState;
+import com.microsoft.jenkins.appservice.commands.FTPDeployCommand;
 import com.microsoft.jenkins.appservice.commands.GitDeployCommand;
 import com.microsoft.jenkins.appservice.commands.TransitionInfo;
 import com.microsoft.jenkins.exceptions.AzureCloudException;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 
 import static org.mockito.Mockito.mock;
@@ -26,8 +30,11 @@ import static org.mockito.Mockito.when;
 
 public class FunctionAppDeploymentCommandContextTest {
 
+    @Rule
+    public TemporaryFolder workspaceDir = new TemporaryFolder();
+
     @Test
-    public void getterSetter() throws AzureCloudException {
+    public void getterSetter() throws AzureCloudException, IOException {
         FunctionAppDeploymentCommandContext ctx = new FunctionAppDeploymentCommandContext("**/*.js,**/*.json");
 
         Assert.assertEquals("", ctx.getSourceDirectory());
@@ -37,8 +44,9 @@ public class FunctionAppDeploymentCommandContextTest {
         Assert.assertFalse(ctx.getIsFinished());
         Assert.assertEquals(DeploymentState.Unknown, ctx.getDeploymentState());
 
-        ctx.setSourceDirectory("src");
-        Assert.assertEquals("src", ctx.getSourceDirectory());
+        File srcDir = workspaceDir.newFolder();
+        ctx.setSourceDirectory(srcDir.getPath());
+        Assert.assertEquals(srcDir.getPath(), ctx.getSourceDirectory());
 
         ctx.setTargetDirectory("target");
         Assert.assertEquals("target", ctx.getTargetDirectory());
@@ -50,7 +58,7 @@ public class FunctionAppDeploymentCommandContextTest {
 
         final Run run = mock(Run.class);
         final TaskListener listener = mock(TaskListener.class);
-        final FilePath workspace = new FilePath(new File("workspace"));
+        final FilePath workspace = new FilePath(workspaceDir.getRoot());
         final FunctionApp app = mock(FunctionApp.class);
         when(app.getPublishingProfile()).thenReturn(pubProfile);
 
@@ -64,11 +72,11 @@ public class FunctionAppDeploymentCommandContextTest {
     }
 
     @Test
-    public void configure() throws AzureCloudException {
+    public void configureNonJava() throws AzureCloudException {
         FunctionAppDeploymentCommandContext ctx = new FunctionAppDeploymentCommandContext("**/*.js,**/*.json");
 
         final Run run = mock(Run.class);
-        final FilePath workspace = new FilePath(new File("workspace"));
+        final FilePath workspace = new FilePath(workspaceDir.getRoot());
         final TaskListener listener = mock(TaskListener.class);
         final FunctionApp app = mock(FunctionApp.class);
 
@@ -77,5 +85,54 @@ public class FunctionAppDeploymentCommandContextTest {
         Assert.assertTrue(commands.containsKey(GitDeployCommand.class));
         Assert.assertEquals(1, commands.size());
         Assert.assertEquals(ctx.getStartCommandClass().getName(), GitDeployCommand.class.getName());
+    }
+
+    @Test
+    public void configureJava() throws AzureCloudException, IOException {
+        FunctionAppDeploymentCommandContext ctx = new FunctionAppDeploymentCommandContext("**/*.jar,**/*.json");
+
+        File file = new File(workspaceDir.getRoot(), "function.json");
+        FileUtils.write(file, "{\"scriptFile\": \"program.jar\"}");
+
+        final Run run = mock(Run.class);
+        final FilePath workspace = new FilePath(workspaceDir.getRoot());
+        final TaskListener listener = mock(TaskListener.class);
+        final FunctionApp app = mock(FunctionApp.class);
+
+        ctx.configure(run, workspace, listener, app);
+        HashMap<Class, TransitionInfo> commands = ctx.getCommands();
+        Assert.assertTrue(commands.containsKey(FTPDeployCommand.class));
+        Assert.assertEquals(1, commands.size());
+        Assert.assertEquals(ctx.getStartCommandClass().getName(), FTPDeployCommand.class.getName());
+    }
+
+    @Test
+    public void assertGetScriptFileFromConfig() throws IOException, InterruptedException {
+        assertGetScriptFileFromConfig("{\"scriptFile\": \"program.jar\"}", "program.jar");
+        assertGetScriptFileFromConfig("{}", "");
+    }
+
+    private void assertGetScriptFileFromConfig(String content, String expScriptFile) throws IOException, InterruptedException {
+        File file = workspaceDir.newFile();
+        FileUtils.write(file, content);
+
+        String scriptFile = FunctionAppDeploymentCommandContext.getScriptFileFromConfig(new FilePath(file));
+        Assert.assertEquals(expScriptFile, scriptFile);
+    }
+
+    @Test
+    public void assertIsJavaFunction() throws IOException, InterruptedException {
+        assertIsJavaFunction("{\"scriptFile\": \"program.jar\"}", true);
+        assertIsJavaFunction("{\"scriptFile\": \"program.js\"}", false);
+        assertIsJavaFunction("{}", false);
+    }
+
+    public void assertIsJavaFunction(String content, boolean exp) throws IOException, InterruptedException {
+        File file = new File(workspaceDir.getRoot(), "function.json");
+        FileUtils.write(file, content);
+
+        boolean isJava = FunctionAppDeploymentCommandContext.isJavaFunction(
+                new FilePath(workspaceDir.getRoot()), "", "**/*.json");
+        Assert.assertEquals(exp, isJava);
     }
 }

--- a/src/test/java/com/microsoft/jenkins/appservice/commands/GitDeployCommandTest.java
+++ b/src/test/java/com/microsoft/jenkins/appservice/commands/GitDeployCommandTest.java
@@ -291,6 +291,4 @@ public class GitDeployCommandTest {
         changed = Whitebox.<Boolean>invokeMethod(command, "isWorkingTreeChanged", git);
         Assert.assertTrue(changed);
     }
-
-
 }


### PR DESCRIPTION
This PR supports Java function by introducing FTP deployment.

A Java function is determined by the content of `function.json`. If we see any `function.json` contains a `scriptFile` field and the value ends with `.jar` suffix, we consider it a Java function and use FTP deployment.