### PR TITLE
upgrade azure sdk and get linuxFxVersion using sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jackson.version>2.7.4</jackson.version>
         <guava.version>19.0</guava.version>
         <powermock.version>1.7.0RC2</powermock.version>
-        <azuresdk.version>1.2.1</azuresdk.version>
+        <azuresdk.version>1.3.0</azuresdk.version>
         <azure-credentials.version>1.2</azure-credentials.version>
         <azure-commons.version>0.1.1</azure-commons.version>
         <version.docker-java>3.0.10</version.docker-java>
@@ -93,6 +93,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-credentials</artifactId>
             <version>${azure-credentials.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.7</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-commons</artifactId>
             <version>${azure-commons.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,6 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.1.7</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-commons</artifactId>
             <version>${azure-commons.version}</version>
         </dependency>

--- a/src/main/java/com/microsoft/jenkins/appservice/WebAppDeploymentRecorder.java
+++ b/src/main/java/com/microsoft/jenkins/appservice/WebAppDeploymentRecorder.java
@@ -197,7 +197,7 @@ public class WebAppDeploymentRecorder extends BaseDeploymentRecorder {
         }
     }
 
-    private DockerBuildInfo validateDockerBuildInfo(final Run<?, ?> run, final TaskListener listener, final WebApp app)
+    private DockerBuildInfo validateDockerBuildInfo(Run<?, ?> run, TaskListener listener, WebApp app)
             throws IOException, InterruptedException, AzureCloudException {
         final DockerBuildInfo dockerBuildInfo = new DockerBuildInfo();
 

--- a/src/main/java/com/microsoft/jenkins/appservice/WebAppDeploymentRecorder.java
+++ b/src/main/java/com/microsoft/jenkins/appservice/WebAppDeploymentRecorder.java
@@ -36,7 +36,6 @@ import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
@@ -202,7 +201,7 @@ public class WebAppDeploymentRecorder extends BaseDeploymentRecorder {
             throws IOException, InterruptedException, AzureCloudException {
         final DockerBuildInfo dockerBuildInfo = new DockerBuildInfo();
 
-        final String linuxFxVersion = getLinuxFxVersion(app);
+        final String linuxFxVersion = app.linuxFxVersion();
         if (StringUtils.isBlank(linuxFxVersion) || isBuiltInDockerImage(linuxFxVersion)) {
             // windows app doesn't need any docker config
             if (StringUtils.isNotBlank(this.publishType)
@@ -269,22 +268,6 @@ public class WebAppDeploymentRecorder extends BaseDeploymentRecorder {
         authConfig.withPassword(credentials[1]);
 
         return authConfig;
-    }
-
-    public static final String getLinuxFxVersion(final WebApp webApp) throws AzureCloudException {
-        // https://github.com/Azure/azure-sdk-for-java/issues/1761
-        // access the field via reflection for now
-        try {
-            final SiteConfigResourceInner siteConfig = (SiteConfigResourceInner) FieldUtils.readField(
-                    webApp, "siteConfig", true);
-            if (siteConfig != null) {
-                return siteConfig.linuxFxVersion();
-            }
-        } catch (IllegalAccessException e) {
-            throw new AzureCloudException(String.format("Cannot get the docker container info of web app %s",
-                    webApp.name()));
-        }
-        return "";
     }
 
     public static boolean isBuiltInDockerImage(final String linuxFxVersion) {

--- a/src/test/java/com/microsoft/jenkins/appservice/integration/ITFTPDeployCommand.java
+++ b/src/test/java/com/microsoft/jenkins/appservice/integration/ITFTPDeployCommand.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.appservice.*;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.jenkins.appservice.util.AzureUtils;
+import com.microsoft.jenkins.azurecommons.JobContext;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.StreamBuildListener;
@@ -40,6 +41,8 @@ public class ITFTPDeployCommand extends IntegrationTest {
         super.setUp();
         command = new FTPDeployCommand();
         commandDataMock = mock(FTPDeployCommand.IFTPDeployCommandData.class);
+        JobContext jobContextMock = mock(JobContext.class);
+        when(commandDataMock.getJobContext()).thenReturn(jobContextMock);
         StreamBuildListener listener = new StreamBuildListener(System.out, Charset.defaultCharset());
         when(commandDataMock.getJobContext().getTaskListener()).thenReturn(listener);
         setUpBaseCommandMockErrorHandling(commandDataMock);

--- a/src/test/java/com/microsoft/jenkins/appservice/integration/ITGitDeployCommand.java
+++ b/src/test/java/com/microsoft/jenkins/appservice/integration/ITGitDeployCommand.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.jenkins.appservice.commands.GitDeployCommand;
 import com.microsoft.jenkins.appservice.util.AzureUtils;
+import com.microsoft.jenkins.azurecommons.JobContext;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -71,6 +72,8 @@ public class ITGitDeployCommand extends IntegrationTest {
         // Create workspace
         File workspaceDir = com.google.common.io.Files.createTempDir();
         workspaceDir.deleteOnExit();
+        JobContext jobContextMock = mock(JobContext.class);
+        when(commandDataMock.getJobContext()).thenReturn(jobContextMock);
         workspace = new FilePath(workspaceDir);
         when(commandDataMock.getJobContext().getWorkspace()).thenReturn(workspace);
 


### PR DESCRIPTION
The newer version(1.3.0) of azure sdk fixed the `linuxFxVersion` issue. The PR upgraded the azure sdk and made changes correspondingly. 