### PR TITLE
Test for 'JAVA|' when determining if the App Service is a Java app

### DIFF
--- a/src/main/java/com/microsoft/jenkins/appservice/util/WebAppUtils.java
+++ b/src/main/java/com/microsoft/jenkins/appservice/util/WebAppUtils.java
@@ -23,12 +23,10 @@ public final class WebAppUtils {
         }
 
         String linuxFxVersion = app.linuxFxVersion();
-        if (StringUtils.isNotBlank(linuxFxVersion) && linuxFxVersion.toLowerCase().contains("jre")) {
-            // Linux container Java App
-            return true;
-        }
-
-        return false;
+        // Linux container Java App
+        return StringUtils.isNotBlank(linuxFxVersion)
+                && (linuxFxVersion.toLowerCase().contains("jre")
+                || linuxFxVersion.startsWith("JAVA|"));
     }
 
     public static boolean isBuiltInDockerImage(WebAppBase app) {

--- a/src/test/java/com/microsoft/jenkins/appservice/util/WebAppUtilsTest.java
+++ b/src/test/java/com/microsoft/jenkins/appservice/util/WebAppUtilsTest.java
@@ -31,6 +31,9 @@ public class WebAppUtilsTest {
 
         when(app.linuxFxVersion()).thenReturn("PHP|5.6");
         Assert.assertFalse(WebAppUtils.isJavaApp(app));
+
+        when(app.linuxFxVersion()).thenReturn("JAVA|11-java11");
+        Assert.assertTrue(WebAppUtils.isJavaApp(app));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes https://issues.jenkins-ci.org/browse/JENKINS-63496

I tested this on our own Jenkins for deployment of a Spring Boot application to Azure App Service with this code in our `Jenkinsfile`:

```
dir('target') {
                    sh '''
                        cp myapp-backend-*.jar app.jar
                        '''
                    zip zipFile: 'app.zip', glob: 'app.jar'

                    azureWebAppPublish azureCredentialsId: 'JenkinsMyAppBackendServicePrincipal',
                            resourceGroup: 'MYAPP-BACKEND',
                            appName: 'myapp-backend-staging',
                            filePath: "app.zip"
                }
```